### PR TITLE
Add BigQuery commit before closing connection

### DIFF
--- a/database/bigquery.py
+++ b/database/bigquery.py
@@ -69,6 +69,7 @@ class BigQuery:
         self._connected = True
 
     def close(self):
+        self.commit()
         self._client.close()
         self._connected = False
 


### PR DESCRIPTION
I configured some urlsets to publish data to GCP BigQuery with full permissions. After the first cron execution, I could see Dawis creating datasets and tables, but no data was written.

Checking the source code, I couldn't find in the source code where the data collected was finally sent to BigQuery. Even though there's a commit() method in the BigQuery class responsible for it, i couldn't find where it's called. So, in the end I decided to add it in the close() method, as it's called for all connections at the end of a scheduled cycle, and it sends all collected data in a batch, instead of one-by-one.

Could you check if this really a bug, and if this is the right place to do apply the fix.

Thanks!

Signed-off-by: Fabio Oliveira <fabio.braga@gmail.com>