### PR TITLE
[BUGFIX] Fix existing row id being null after insert

### DIFF
--- a/database/orm/tables/urls_urlset.py
+++ b/database/orm/tables/urls_urlset.py
@@ -31,8 +31,13 @@ class UrlsUrlset(_AbstractTable):
         if existing_row_id is not None:
             return existing_row_id
 
-        result = self._orm.execute(
+        self._orm.execute(
             self._table.insert().values(id=row_id, protocol=protocol, domain=domain, path=path, query=query)
         )
 
-        return result.inserted_primary_key[0]
+        existing_row_id = self._check_existing_url(protocol, domain, path, query)
+
+        if existing_row_id is None:
+            raise Exception("URL not found after insert.")
+
+        return existing_row_id


### PR DESCRIPTION
I got this error with the pagespeed operation:
```
dawis_debug  | Traceback (most recent call last):
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1910, in _execute_context
dawis_debug  |     self.dialect.do_execute(
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
dawis_debug  |     cursor.execute(statement, parameters)
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/cursors.py", line 153, in execute
dawis_debug  |     result = self._query(query)
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/cursors.py", line 322, in _query
dawis_debug  |     conn.query(q)
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/connections.py", line 558, in query
dawis_debug  |     self._affected_rows = self._read_query_result(unbuffered=unbuffered)
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/connections.py", line 822, in _read_query_result
dawis_debug  |     result.read()
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/connections.py", line 1200, in read
dawis_debug  |     first_packet = self.connection._read_packet()
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/connections.py", line 772, in _read_packet
dawis_debug  |     packet.raise_for_error()
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/protocol.py", line 221, in raise_for_error
dawis_debug  |     err.raise_mysql_exception(self._data)
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
dawis_debug  |     raise errorclass(errno, errval)
dawis_debug  | pymysql.err.IntegrityError: (1048, "Column 'url' cannot be null")
dawis_debug  | 
dawis_debug  | The above exception was the direct cause of the following exception:
dawis_debug  | 
dawis_debug  | Traceback (most recent call last):
dawis_debug  |   File "/app/module-debugger.py", line 24, in <module>
dawis_debug  |     run(configuration.hash, configuration_key, operationModule.module, 'modules.operation.custom')
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/celery/local.py", line 191, in __call__
dawis_debug  |     return self._get_current_object()(*a, **kw)
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/celery/app/task.py", line 393, in __call__
dawis_debug  |     return self.run(*args, **kwargs)
dawis_debug  |   File "/app/modules/runner.py", line 25, in run
dawis_debug  |     customclass(configuration, configuration_key, connection).run()
dawis_debug  |   File "/app/modules/operation/custom/pagespeed.py", line 40, in run
dawis_debug  |     self.check_fcp_score(urlset_name, url, 'fcp_score', pagespeed_json_desktop, 'desktop')
dawis_debug  |   File "/app/modules/operation/custom/pagespeed.py", line 161, in check_fcp_score
dawis_debug  |     self.check_service.add_check(
dawis_debug  |   File "/app/service/check.py", line 57, in add_check
dawis_debug  |     self._urlset_checks_table.add(urlset, url_id, check, valid, value, diff, error)
dawis_debug  |   File "/app/database/orm/tables/checks_urlset.py", line 34, in add
dawis_debug  |     result = self._orm.execute(self._table.insert().values(
dawis_debug  |   File "/app/database/orm/__init__.py", line 46, in execute
dawis_debug  |     return self._connection.execute(statement)
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1385, in execute
dawis_debug  |     return meth(self, multiparams, params, _EMPTY_EXECUTION_OPTS)
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/sql/elements.py", line 334, in _execute_on_connection
dawis_debug  |     return connection._execute_clauseelement(
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1577, in _execute_clauseelement
dawis_debug  |     ret = self._execute_context(
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1953, in _execute_context
dawis_debug  |     self._handle_dbapi_exception(
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 2134, in _handle_dbapi_exception
dawis_debug  |     util.raise_(
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
dawis_debug  |     raise exception
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1910, in _execute_context
dawis_debug  |     self.dialect.do_execute(
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 736, in do_execute
dawis_debug  |     cursor.execute(statement, parameters)
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/cursors.py", line 153, in execute
dawis_debug  |     result = self._query(query)
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/cursors.py", line 322, in _query
dawis_debug  |     conn.query(q)
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/connections.py", line 558, in query
dawis_debug  |     self._affected_rows = self._read_query_result(unbuffered=unbuffered)
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/connections.py", line 822, in _read_query_result
dawis_debug  |     result.read()
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/connections.py", line 1200, in read
dawis_debug  |     first_packet = self.connection._read_packet()
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/connections.py", line 772, in _read_packet
dawis_debug  |     packet.raise_for_error()
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/protocol.py", line 221, in raise_for_error
dawis_debug  |     err.raise_mysql_exception(self._data)
dawis_debug  |   File "/usr/local/lib/python3.9/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
dawis_debug  |     raise errorclass(errno, errval)
dawis_debug  | sqlalchemy.exc.IntegrityError: (pymysql.err.IntegrityError) (1048, "Column 'url' cannot be null")
```
I then logged the result from the insert and `result.inserted_primary_key[0]` actually was `None`.